### PR TITLE
Hide pages for videos, insurance, and portfolio

### DIFF
--- a/FIN/public/index.html
+++ b/FIN/public/index.html
@@ -24,10 +24,8 @@
                 <li><a href="https://www.tribushonline.com">Home</a></li>
                 <li><a href="https://www.tribushonline.com/links/about.html">About</a></li>
                 <li><a href="https://www.tribushonline.com/links/blog.html">Blog</a></li>
-                <li><a href="https://www.tribushonline.com/links/portfolio.html">Portfolio</a></li>
                 <li><a href="https://www.tribushonline.com/links/shop.html">Shop</a></li>
                 <li><a href="https://www.tribushonline.com/links/hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="https://www.tribushonline.com/links/videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/SerScripts.js
+++ b/SerScripts.js
@@ -6,21 +6,10 @@ document.addEventListener("DOMContentLoaded", () => {
         { name: "Home", url: "https://www.tribushonline.com/index.html" },
         { name: "About", url: "https://www.tribushonline.com/links/about.html" },
         { name: "Blog", url: "https://www.tribushonline.com/links/blog.html" },
-        { name: "Portfolio", url: "https://www.tribushonline.com/links/portfolio.html" },
         { name: "Shop", url: "https://www.tribushonline.com/links/shop.html" },
         { name: "Hidden Gems", url: "https://www.tribushonline.com/links/hidden-gems.html" },
-        { name: "Videos", url: "https://www.tribushonline.com/links/videos.html" },
-        { name: "Podcast", url: "https://www.tribushonline.com/links/videos.html" },
-        { name: "YouTube", url: "https://www.tribushonline.com/links/videos.html" },
         { name: "Financial Calculator", url: "https://fin.tribushonline.com/" },
-        { name: "Debt", url: "https://www.tribushonline.com/links/debt-solutions.html" },
-        { name: "Life", url: "https://www.tribushonline.com/links/life-insurance.html" },
-        { name: "Life Insurance", url: "https://www.tribushonline.com/links/life-insurance.html" },
-        { name: "Insurance", url: "https://www.tribushonline.com/links/insurance.html" },
-        { name: "IUL", url: "https://www.tribushonline.com/links/iul-/insurance.html" },
-        { name: "Term", url: "https://www.tribushonline.com/links/term-life-insurance.html" },
-        { name: "Whole", url: "https://www.tribushonline.com/links/whole-life-insurance.html" },
-        // Add more pages or articles here
+        { name: "Debt", url: "https://www.tribushonline.com/links/debt-solutions.html" }
     ];
 
     console.log("JavaScript loaded");

--- a/index.html
+++ b/index.html
@@ -101,10 +101,8 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="links/about.html">About</a></li>
                 <li><a href="links/blog.html">Blog</a></li>
-                <li><a href="links/portfolio.html">Portfolio</a></li>
                 <li><a href="links/shop.html">Shop</a></li>
                 <li><a href="links/hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="links/videos.html">Videos</a></li>
                 <!-- Add the search bar inside the nav list -->
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
@@ -123,11 +121,6 @@
                 <h3>Debt Solutions</h3>
                 <p>Reduce your debt with personalized solutions. Lower interest rates, reduce monthly payments, and avoid bankruptcy.</p>
                 <a href="links/debt-solutions.html">Learn More</a>
-            </div>
-            <div class="service-card">
-                <h3>Insurance Services</h3>
-                <p>Protect your future with our comprehensive insurance services, including Life Insurance, IUL, Term, and Whole Life policies.</p>
-                <a href="links/insurance.html">Learn More</a>
             </div>
         </div>
     </section>

--- a/links/blog.html
+++ b/links/blog.html
@@ -68,10 +68,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/debt-solutions.html
+++ b/links/debt-solutions.html
@@ -50,10 +50,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/delete-data.html
+++ b/links/delete-data.html
@@ -18,10 +18,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
             </ul>
         </nav>
     </header>

--- a/links/f&g-overview.html
+++ b/links/f&g-overview.html
@@ -52,10 +52,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/final-expense-insurance.html
+++ b/links/final-expense-insurance.html
@@ -73,10 +73,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/hidden-gems.html
+++ b/links/hidden-gems.html
@@ -62,10 +62,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/insurance.html
+++ b/links/insurance.html
@@ -60,10 +60,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/iul-insurance.html
+++ b/links/iul-insurance.html
@@ -73,10 +73,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/life-insurance.html
+++ b/links/life-insurance.html
@@ -73,10 +73,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/moo-overview.html
+++ b/links/moo-overview.html
@@ -54,10 +54,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/nlg-overview.html
+++ b/links/nlg-overview.html
@@ -53,10 +53,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/portfolio.html
+++ b/links/portfolio.html
@@ -54,10 +54,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/shop.html
+++ b/links/shop.html
@@ -68,10 +68,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>
@@ -87,11 +85,6 @@
                 <h3>Debt Solutions</h3>
                 <p>Reduce your debt with personalized solutions. Lower interest rates to 0%, reduce monthly payments, and avoid bankruptcy.</p>
                 <a href="debt-solutions.html">Learn More</a>
-            </div>
-            <div class="grid-card">
-                <h3>Insurance Services</h3>
-                <p>Protect your future with our comprehensive insurance services, including Life Insurance, IUL, Term, and Whole Life policies.</p>
-                <a href="insurance.html">Learn More</a>
             </div>
         </div>
     </section>

--- a/links/term-life-insurance.html
+++ b/links/term-life-insurance.html
@@ -73,10 +73,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/videos.html
+++ b/links/videos.html
@@ -18,10 +18,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search..." autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>

--- a/links/whole-life-insurance.html
+++ b/links/whole-life-insurance.html
@@ -73,10 +73,8 @@
                 <li><a href="../index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="blog.html">Blog</a></li>
-                <li><a href="portfolio.html">Portfolio</a></li>
                 <li><a href="shop.html">Shop</a></li>
                 <li><a href="hidden-gems.html">Hidden Gems</a></li>
-                <li><a href="videos.html">Videos</a></li>
                 <li>
                     <input type="text" id="search-bar" placeholder="Search... " autocomplete="off">
                     <ul id="suggestions" class="suggestions"></ul>


### PR DESCRIPTION
## Summary
- strip portfolio and videos from navigation across the site
- remove Insurance card and references from the home and shop pages
- drop hidden pages from search suggestions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68423ac2ed1c832ab3091f1c923f3e3c