### PR TITLE
Add SiteScan software page and integrate into homepage + site search

### DIFF
--- a/SerScripts.js
+++ b/SerScripts.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
         { name: "BlockSurvival Wiki", url: "links/game-wiki.html" },
         { name: "Project Insight", url: "links/asset-tool.html" },
         { name: "NeoLock", url: "links/neolock.html" },
+        { name: "SiteScan - Offline SEO Scanner", url: "links/sitescan.html" },
         { name: "Dev Log", url: "links/dev-log.html" },
         { name: "Portfolio", url: "links/portfolio.html" },
         { name: "About", url: "links/about.html" },

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                 <li><a href="links/game-wiki.html">BlockSurvival Wiki</a></li>
                 <li><a href="links/asset-tool.html">Project Insight</a></li>
                 <li><a href="links/neolock.html">NeoLock</a></li>
+                <li><a href="links/sitescan.html">SiteScan</a></li>
                 <li><a href="links/dev-log.html">Dev Log</a></li>
                 <li><a href="links/portfolio.html">Portfolio</a></li>
                 <li><a href="links/about.html">About</a></li>
@@ -91,6 +92,12 @@
                     <h3>NeoLock</h3>
                     <p>A fast, offline password generator and encrypted vault that keeps every entry local and protected by AES-256.</p>
                     <a class="button secondary" href="links/neolock.html">Explore NeoLock</a>
+                </article>
+                <article class="card">
+                    <span class="meta">SEO Software</span>
+                    <h3>SiteScan - Offline SEO Scanner</h3>
+                    <p>An offline SEO scanner for technical audits, metadata checks, heading structure reviews, and internal link diagnostics.</p>
+                    <a class="button secondary" href="links/sitescan.html">Discover SiteScan</a>
                 </article>
                 <article class="card">
                     <span class="meta">Knowledge Share</span>

--- a/links/sitescan.html
+++ b/links/sitescan.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="SiteScan is an offline SEO scanner that audits pages, metadata, headings, links, and technical issues without uploading your website data to the cloud.">
+    <meta name="google-adsense-account" content="ca-pub-2593431830550121">
+    <title>SiteScan - Offline SEO Scanner | TriBush</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body oncontextmenu="return false;">
+    <header>
+        <nav>
+            <a class="brand" href="../index.html">
+                <img src="../images/logo.png" alt="TriBush Logo">
+                <span>TriBush</span>
+            </a>
+            <ul class="nav-links">
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="game-wiki.html">BlockSurvival Wiki</a></li>
+                <li><a href="asset-tool.html">Project Insight</a></li>
+                <li><a href="neolock.html">NeoLock</a></li>
+                <li><a class="active" href="sitescan.html">SiteScan</a></li>
+                <li><a href="dev-log.html">Dev Log</a></li>
+                <li><a href="portfolio.html">Portfolio</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+                <li class="nav-search">
+                    <input type="text" id="search-bar" placeholder="Search the site" autocomplete="off">
+                    <ul id="suggestions" class="suggestions"></ul>
+                </li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="container hero">
+            <div class="hero-copy">
+                <span class="eyebrow">Offline SEO audit software</span>
+                <h1>SiteScan - Offline SEO Scanner</h1>
+                <p>SiteScan helps creators, agencies, and in-house teams run fast technical SEO audits locally. Crawl pages, validate metadata, review headings, inspect internal links, and uncover indexing blockers without sending sensitive project data to third-party servers.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="https://tribush.itch.io/sitescan-offline-seo-scanner" target="_blank" rel="noopener">Buy SiteScan on itch.io</a>
+                    <a class="button secondary" href="#features">Explore features</a>
+                </div>
+            </div>
+            <div class="hero-panels">
+                <article class="panel">
+                    <h2>SEO checks that matter</h2>
+                    <ul class="feature-list">
+                        <li>Title tags and meta descriptions.</li>
+                        <li>H1-H6 hierarchy and heading consistency.</li>
+                        <li>Broken links and redirect chains.</li>
+                        <li>Image alt text and missing metadata.</li>
+                        <li>Crawlability and technical signal review.</li>
+                    </ul>
+                </article>
+                <article class="panel">
+                    <h2>Private by design</h2>
+                    <p>Run scans on your own machine to keep client websites, staging environments, and internal projects confidential.</p>
+                    <p class="section-subtitle">Perfect for SEO professionals who need local-first workflows and clear audit output.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="container section" id="features">
+            <div class="section-header">
+                <h2 class="section-title">Why use SiteScan for SEO audits?</h2>
+                <p class="section-subtitle">From quick health checks to deep diagnostics, SiteScan gives you actionable on-page SEO insight.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <span class="meta">On-page SEO</span>
+                    <h3>Find metadata gaps fast</h3>
+                    <p>Identify duplicate or missing title tags, weak meta descriptions, and page-level signals that affect click-through rates and rankings.</p>
+                </article>
+                <article class="card">
+                    <span class="meta">Technical SEO</span>
+                    <h3>Uncover crawl issues</h3>
+                    <p>Flag broken links, redirect loops, and architecture problems that can dilute authority and hurt discoverability.</p>
+                </article>
+                <article class="card">
+                    <span class="meta">Content structure</span>
+                    <h3>Improve heading clarity</h3>
+                    <p>Review H1-H6 structure to maintain semantic order, support accessibility, and make each page easier for search engines to parse.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="container section" id="who">
+            <div class="section-header">
+                <h2 class="section-title">Built for marketers, developers, and site owners</h2>
+                <p class="section-subtitle">Use SiteScan to optimize pages before launch, during migrations, or as part of recurring SEO maintenance.</p>
+            </div>
+            <div class="grid-two">
+                <article class="card highlight">
+                    <h3>SEO consultants &amp; agencies</h3>
+                    <p>Run repeatable audits for clients, prioritize fixes by impact, and present clean findings in strategy calls.</p>
+                </article>
+                <article class="card">
+                    <h3>Product &amp; web teams</h3>
+                    <p>Validate technical SEO before deployment and catch issues early so your launch keeps organic momentum.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="container section" id="get">
+            <div class="section-header">
+                <h2 class="section-title">Get SiteScan</h2>
+                <p class="section-subtitle">Purchase once and start auditing websites locally with an offline SEO workflow.</p>
+            </div>
+            <div class="grid-two">
+                <article class="card highlight">
+                    <h3>itch.io storefront</h3>
+                    <p>Buy SiteScan directly from TriBush and access the Offline SEO Scanner download from itch.io.</p>
+                    <a class="button primary" href="https://tribush.itch.io/sitescan-offline-seo-scanner" target="_blank" rel="noopener">Open product page</a>
+                </article>
+                <article class="card">
+                    <h3>Questions before you buy?</h3>
+                    <p>Email <a href="mailto:tribushonline@gmail.com">tribushonline@gmail.com</a> for compatibility details, roadmap plans, or support guidance.</p>
+                    <a class="button secondary" href="mailto:tribushonline@gmail.com">Contact TriBush</a>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="footer-inner">
+            <p>&copy; <span id="year"></span> TriBush. All rights reserved.</p>
+            <div class="footer-links">
+                <a href="privacy-policy.html">Privacy</a>
+                <a href="delete-data.html">Data Removal</a>
+                <a href="https://buymeacoffee.com/tribush" target="_blank" rel="noopener">Support the work</a>
+            </div>
+        </div>
+        <a href="https://buymeacoffee.com/tribush" class="donate-button" target="_blank" rel="noopener">Buy Me a Coffee</a>
+    </footer>
+
+    <script>
+        const yearElement = document.getElementById('year');
+        if (yearElement) {
+            yearElement.textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../SerScripts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a product page for SiteScan so the offline SEO scanner is represented on the site with SEO-focused copy and a purchase CTA. 
- Keep the new page consistent with the existing product layout and visual style used across other software pages. 
- Make SiteScan discoverable from the homepage and searchable via the site search so visitors can find it quickly. 

### Description
- Added a new product page at `links/sitescan.html` using the same hero, feature, and CTA sections as other product pages and pointing the purchase link to `https://tribush.itch.io/sitescan-offline-seo-scanner`. 
- Updated `index.html` to add a top navigation link to SiteScan and a new spotlight card so it appears on the home page alongside other featured projects. 
- Updated `SerScripts.js` to include `{ name: "SiteScan - Offline SEO Scanner", url: "links/sitescan.html" }` in the search pages array so the page appears in search suggestions and exact-match navigation. 
- Ensured `SerScripts.js` remains valid JavaScript after the change. 

### Testing
- Ran a Node-based syntax check by parsing `SerScripts.js` with `new Function(...)` and the validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa5f8721883208ed84b8725721591)